### PR TITLE
Puts warn when Object#delay is called with block

### DIFF
--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -7,8 +7,8 @@ module Delayed
     end
 
     # rubocop:disable MethodMissing
-    def method_missing(method, *args)
-      Job.enqueue({:payload_object => @payload_class.new(@target, method.to_sym, args)}.merge(@options))
+    def method_missing(method, *args, &block)
+      Job.enqueue({:payload_object => @payload_class.new(@target, method.to_sym, args, &block)}.merge(@options))
     end
     # rubocop:enable MethodMissing
   end

--- a/lib/delayed/performable_method.rb
+++ b/lib/delayed/performable_method.rb
@@ -2,8 +2,9 @@ module Delayed
   class PerformableMethod
     attr_accessor :object, :method_name, :args
 
-    def initialize(object, method_name, args)
+    def initialize(object, method_name, args, &block)
       raise NoMethodError, "undefined method `#{method_name}' for #{object.inspect}" unless object.respond_to?(method_name, true)
+      warn "Ignored the block #{block.inspect} because it cannot be serialized." if block_given?
 
       if object.respond_to?(:persisted?) && !object.persisted?
         raise(ArgumentError, "job cannot be created for non-persisted record: #{object.inspect}")


### PR DESCRIPTION
## 変更内容
Object#delayがブロックとともに呼ばれたときに警告を出すようにした。
結局、ProcやBlockはYAMLにシリアライズできないので、Jobにenqueueできないので...

## 背景

```ruby
Article.first.delay.tap do |article|
  article.touch
end
```

をDelayedJobのバックエンドで実行すると、以下の例外がraiseされる。もともとblockはダメだって分かってるんだからwarnでも出しておくべきかと思った。

```
LocalJumpError: no block given
```